### PR TITLE
Add brackets around the category name so the module shows up properly…

### DIFF
--- a/grc/ais_invert.xml
+++ b/grc/ais_invert.xml
@@ -2,7 +2,7 @@
 <block>
   <name>invert</name>
   <key>ais_invert</key>
-  <category>ais</category>
+  <category>[ais]</category>
   <import>import ais</import>
   <make>ais.invert()</make>
   <sink>

--- a/grc/ais_pdu_to_nmea.xml
+++ b/grc/ais_pdu_to_nmea.xml
@@ -2,7 +2,7 @@
 <block>
   <name>pdu_to_nmea</name>
   <key>ais_pdu_to_nmea</key>
-  <category>ais</category>
+  <category>[ais]</category>
   <import>import ais</import>
   <make>ais.pdu_to_nmea($designator)</make>
 

--- a/grc/ais_square_and_fft_sync_cc.xml
+++ b/grc/ais_square_and_fft_sync_cc.xml
@@ -2,7 +2,7 @@
 <block>
   <name>square_and_fft_sync_cc</name>
   <key>ais_square_and_fft_sync</key>
-  <category>ais</category>
+  <category>[ais]</category>
   <import>from ais import gmsk_sync</import>
   <make>gmsk_sync.square_and_fft_sync_cc($rate, $sps, $fftlen)</make>
   <!-- Make one 'param' node for every Parameter you want settable from the GUI.


### PR DESCRIPTION
… starting in Gnuradio 3.7.10. See http://marc.info/?l=gnuradio-discuss&m=147873597211638&w=2

